### PR TITLE
Updated wrong links leading to 404 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,7 @@
 				<div class="element">
 					<img class="group" src="images/Group7.png" alt="">
 					<p>Check Account and Merchant point-of-sale</p>
-					<a
-						href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#check-account-and-pos"><img
+					<a href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#check-account-and-pos"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 				<div class="element">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
@@ -11,26 +12,12 @@
 	<link rel="stylesheet" href="css/normalize.css">
 	<link rel="stylesheet" href="css/main.css">
 </head>
-<section class="notice">
-                             <div class="banner">
-                                           <div class="banner-content">
-                                                          <p style="color:#005A83">Inviting interested developers, implementers and other members of the financial services community to attend the next online 
-								  	Mojaloop Community Meeting on April 20-24 2020. </br> </br> If you are interested in participating, please contact:
-                                                                        <u><a href="mailto: kimw@crosslaketech.com">Kim Walters</a></u> or <u><a
-                                                                                                     href="mailto: phunter@virtualinc.com">Paula Hunter</a></u>.
-                                                          </p>
-                                           </div>
-                             </div>
-              </section>
-
-	
-
 <body>
 	<!-- Google Tag Manager (noscript) -->
 	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PCQCZFS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<!-- End Google Tag Manager (noscript) -->
 
-	
+
 	<section class="header">
 		<div class="section-container">
 			<div class="head">
@@ -40,18 +27,19 @@
 				Mojaloop is open-source software for financial services companies, government regulators, and others taking on
 				the challenges of interoperability and financial inclusion.
 			</p>
-			<div class="button-container"> 
+			<div class="button-container">
 				<div class="item">
-					<a class="btn__git" href="https://mojaloop.io/documentation">View technical documentation</a>
-					<a class="btn__git" href="https://mojaloop.io/mojaloop-business-docs">View business documentation</a>
-					<a class="btn__git" href="https://mojaloop.io/mojaloop-specification/">View specification documentation</a>
+					<a class="btn__git" href="https://docs.mojaloop.io/documentation">View technical documentation</a>
+					<a class="btn__git" href="https://docs.mojaloop.io/mojaloop-business-docs">View business documentation</a>
+					<a class="btn__git" href="https://docs.mojaloop.io/mojaloop-specification/">View specification
+						documentation</a>
 				</div>
 			</div>
 			<div class="mobile">
 				<img src="images/happy_women.png" alt="">
-				<a class="btn__git " href="https://mojaloop.io/documentation">View technical documentation</a>
-				<a class="btn__git" href="https://mojaloop.io/mojaloop-business-docs">View business documentation</a>
-				<a class="btn__git" href="https://mojaloop.io/mojaloop-specification/">View specification documentation</a>
+				<a class="btn__git " href="https://docs.mojaloop.io/documentation">View technical documentation</a>
+				<a class="btn__git" href="https://docs.mojaloop.io/mojaloop-business-docs">View business documentation</a>
+				<a class="btn__git" href="https://docs.mojaloop.io/mojaloop-specification/">View specification documentation</a>
 			</div>
 
 			<iframe width="240" height="135" src="https://www.youtube.com/embed/hEa1-Ra5R1g?rel=0" frameborder="0"
@@ -69,8 +57,9 @@
 					<h2>Why was it made?</h2>
 					<p>Customers should be able to send digital payments to anyone, regardless of what kind of account or service
 						they use. Mojaloop makes it easier for financial providers to achieve interoperability. Learn more in our <a
-							href="https://docs.mojaloop.live/mojaloop-background">Mojaloop background</a> and <a
-							href="https://docs.mojaloop.live/contributors-guide/frequently-asked-questions.html">FAQ.</a></p>
+							href="https://docs.mojaloop.io/documentation/mojaloop-background/">Mojaloop background</a> and <a
+							href="https://docs.mojaloop.io/documentation/contributors-guide/frequently-asked-questions.html">FAQ.</a>
+					</p>
 				</div>
 			</div>
 			<div class="right">
@@ -81,7 +70,8 @@
 							code.</a> In particular, it enables central banks, market infrastructures, payment processors, and fintech
 						firms to accelerate the creation and deployment of interoperable payment platforms that can scale in serving
 						the poor. It gives existing payment processors and providers a level playing field to connect to. See our <a
-							href="https://docs.mojaloop.live/contributors-guide/frequently-asked-questions.html">FAQ</a> for more.
+							href="https://docs.mojaloop.io/documentation/contributors-guide/frequently-asked-questions.html">FAQ</a>
+						for more.
 					</p>
 				</div>
 			</div>
@@ -95,7 +85,7 @@
 				<div class="text left">
 					<p>The Account Lookup Service (ALS) routes each payment to the correct service/provider in the ecosystem.</p>
 					<a class="btn__inside"
-						href="http://mojaloop.io/documentation/mojaloop-technical-overview/account-lookup-service">view
+						href="https://docs.mojaloop.io/documentation/mojaloop-technical-overview/account-lookup-service/">view
 						documentation <i class="arrow right"></i></a>
 				</div>
 				<div class="animation-image height image-left">
@@ -107,19 +97,18 @@
 					<img src="images/Building_bars_complete.gif" alt="">
 				</div>
 				<div class="text right">
-					<p>The Central Ledger is a series of services that facilitate clearing and settlement of transfers between
-						DFSPs.</p>
+					<p>The Central Ledger is a series of services that facilitate clearing and settlement of transfers between DFSPs.</p>
 					<a class="btn__inside"
-						href="http://mojaloop.io/documentation/mojaloop-technical-overview/central-ledger/">view documentation <i
-							class="arrow right"></i></a>
+						href="https://docs.mojaloop.io/documentation/mojaloop-technical-overview/central-ledger/">view
+						documentation <i class="arrow right"></i></a>
 				</div>
 			</div>
 			<div class="column">
 				<div class="text left">
-					<p>The Central Settlements service exposes Settlement API to manage the settlements between FSPs and the
-						Central Hub</p>
+					<p>The Central Settlements service exposes Settlement API to manage the settlements between FSPs and the Central Hub</p>
 					<a class="btn__inside"
-						href="http://mojaloop.io/documentation/mojaloop-technical-overview/central-settlements/">view documentation
+						href="https://docs.mojaloop.io/documentation/mojaloop-technical-overview/central-settlements/">view
+						documentation
 						<i class="arrow right"></i></a>
 
 				</div>
@@ -135,7 +124,7 @@
 					<p>The Mojaloop Hub is the primary container and reference we use to describe the core Mojaloop components.
 					</p>
 					<a class="btn__inside"
-						href="http://mojaloop.io/documentation/mojaloop-technical-overview/mojaloop-components.html">view
+						href="https://docs.mojaloop.io/documentation/mojaloop-technical-overview/mojaloop-components.html">view
 						documentation <i class="arrow right"></i></a>
 				</div>
 			</div>
@@ -149,33 +138,33 @@
 				<div class="element">
 					<img class="group" src="images/Group6.png" alt="">
 					<p>Person-to-person transfers</p>
-					<a
-						href="https://http://mojaloop.io/documentation/mojaloop-background/core-scenarios.html#send-money-to-anyone"><img
+					<a href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#send-money-to-anyone"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 				<div class="element">
 					<img class="group" src="images/Group7.png" alt="">
 					<p>Check Account and Merchant point-of-sale</p>
-					<a href="http://mojaloop.io/documentation/mojaloop-background/core-scenarios.html#check-account-and-pos"><img
+					<a
+						href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#check-account-and-pos"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 				<div class="element">
 					<img class="group" src="images/Group18.png" alt="">
 					<p>Payroll and other bulk payments</p>
-					<a href="http://mojaloop.io/documentation/mojaloop-background/core-scenarios.html#bulk-payments"><img
+					<a href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#bulk-payments"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 				<div class="element">
 					<img class="group" src="images/Group19.png" alt="">
 					<p>Account Management</p>
-					<a href="http://mojaloop.io/documentation/mojaloop-background/core-scenarios.html#account-management"><img
+					<a href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#account-management"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 				<div class="element">
 					<img class="group" src="images/Group20.png" alt="">
 					<p>Fraud monitoring</p>
 					<a
-						href="http://mojaloop.io/documentation/mojaloop-background/core-scenarios.html#fraud-checks-and-blacklists"><img
+						href="https://docs.mojaloop.io/documentation/mojaloop-background/core-scenarios.html#fraud-checks-and-blacklists"><img
 							src="images/arrow_small.png" alt=""></a>
 				</div>
 			</div>
@@ -187,7 +176,7 @@
 			<h2>Get started</h2>
 			<div class="content">
 				<div class="item">
-					<a class="btn__git" href="http://mojaloop.io/documentation/contributors-guide/">Contributors Guide</a>
+					<a class="btn__git" href="https://docs.mojaloop.io/documentation/contributors-guide/">Contributors Guide</a>
 				</div>
 				<div class="item">
 					<a class="btn__git" href="https://github.com/mojaloop/mojaloop">View on GitHub</a>
@@ -225,4 +214,5 @@
 		</div>
 	</footer>
 </body>
+
 </html>


### PR DESCRIPTION
Updated the following links on https://docs.mojaloop.io  that were leading to 404 errors:

- Business documentation links
- Mojaloop Background
- FAQs
- ALS
- Central Ledger
- Scenarios